### PR TITLE
Update tutorial to reflect 4.1.0.0 version

### DIFF
--- a/tutorials/T2-SymbolicComputation.txt
+++ b/tutorials/T2-SymbolicComputation.txt
@@ -187,8 +187,8 @@ which reads the number n from the command line:
 -----------------
 import Smten.Prelude
 import Smten.Control.Monad
-import Smten.Search
-import Smten.Search.Solver.MiniSat
+import Smten.Symbolic
+import Smten.Symbolic.Solver.MiniSat
 import Smten.System.Environment
 
 -- Placement: A list of locations (row, col) for each queen.
@@ -211,12 +211,12 @@ islegal places = and [
   distinct (map (uncurry (+)) places),
   distinct (map (uncurry (-)) places)]
 
-mkcol :: Int -> Space Int
+mkcol :: Int -> Symbolic Int
 mkcol n = msum (map return [0..(n-1)])
 
 nqueens :: Int -> IO ()
 nqueens n = do
-  result <- search minisat $ do
+  result <- run_symbolic minisat $ do
               let rows = [0..(n-1)]
               cols <- replicateM n (mkcol n)
               let places = zip rows cols


### PR DESCRIPTION
In the released 4.1.0.0 version, Space is called Symbolic, and some other functions and modules do not have their new names.
The first tutorial suggests to install the 4.1.0.0 release, so these two documents are not consistent right now.
